### PR TITLE
Fix link to WordPress blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,8 @@ How do I undo this?
         proxy_pass https://baltimorenode.github.io/temporary-homepage/;
     }
     ```
-1. Remove WordPress hack:
-    ```
-    root@localhost:/home/nodepress/www.baltimorenode.org/www# diff canonical.php__before-jnm-hack-20200325 wp-includes/canonical.php 
-    440c440,441
-    < 	$redirect['path'] = preg_replace( '|/' . preg_quote( $wp_rewrite->index, '|' ) . '/*?$|', '/', $redirect['path'] );
-    ---
-    > 	// 20200325 jnm hacking wordpress core... what could go wrong? uncomment following line to undo
-    > 	//$redirect['path'] = preg_replace( '|/' . preg_quote( $wp_rewrite->index, '|' ) . '/*?$|', '/', $redirect['path'] );
-    ```
+1. (Optionally) Remove WordPress `home` location:
+
+    https://baltimorenode.org/home is provided by the https://redirection.me/ WordPress plugin, but it's not actually a redirect.
+    It's simply configured to pass-through the location `/`, and because it does this at the WordPress level,
+    it bypasses the NGINX `proxy_pass` described above.

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
                         <li>Join our <strong>Discord</strong> server: <a href="https://discord.gg/GsUkRzH">https://discord.gg/GsUkRzH</a></li>
                         <li>Join our <strong>public discussion</strong> list: <a href="https://groups.google.com/forum/#!forum/baltimore-node-discussion">https://groups.google.com/forum/#!forum/baltimore-node-discussion</a></li>
                         <li>Collaborate on <a href="https://wiki.baltimorenode.org/">our <strong>wiki</strong></a></li>
-                        <li>Visit our <a href="https://baltimorenode.org/index.php"><strong>main website</strong> / blog</a>
+                        <li>Visit our <a href="https://baltimorenode.org/home"><strong>main website</strong> / blog</a>
                         <li>RSVP to our <em>virtual</em> events on <strong>Meetup</strong>: <a href="https://www.meetup.com/baltimorenode/">https://www.meetup.com/baltimorenode/</a></li>
                         <li><small>Contact our entire membership: email &quot;inquiries@discuss.&quot; plus the domain name of this website <button onclick="alert(discoAddress('inquiries'))">what?</button></small></li>
                         <li><small>If <em>and only if</em> your message must be restricted to current and former officers: email &quot;root@&quot; plus the domain name of this website <button onclick="alert(rootAddress())">what?</button></small></li>


### PR DESCRIPTION
My evil hack of WordPress' `canonical.php` was being overwritten on each update