### PR TITLE
Revert "Add placeholder page for annual meeting"

### DIFF
--- a/annualmeeting/index.html
+++ b/annualmeeting/index.html
@@ -1,8 +1,0 @@
-<html>
-<head>
-<title>Baltimore Node - Annual Meeting</title>
-</head>
-<body>
-<h1>2021 Baltimore Node Annual Meeting</h1>
-</body>
-</html>


### PR DESCRIPTION
Reverts baltimorenode/temporary-homepage#4

`/annualmeeting` is being served by WordPress